### PR TITLE
Unify deployment target between SPM and cocoapods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "base45-swift",
+    platforms: [
+        .macOS(.v10_11),
+        .iOS(.v10),
+        .tvOS(.v10),
+        .watchOS(.v3)
+    ],
     products: [
         .library(
             name: "base45-swift",

--- a/base45-swift.podspec
+++ b/base45-swift.podspec
@@ -19,7 +19,10 @@ For this reason - the industry generally encodes these in base45. A document for
   spec.homepage     = "https://github.com/ehn-digital-green-development/base45-swift"
   spec.license      = "Apache License"
   spec.authors      = { "Hannes Van den Berghe" => "hannes.vandenberghe@icapps.com", "Dirk-Willem van Gulik" => "dirkx@webweaving.org" }
-  spec.ios.deployment_target = "12.0"
+  spec.ios.deployment_target = '10.0'
+  spec.osx.deployment_target = '10.11'
+  spec.tvos.deployment_target = '10.0'
+  spec.watchos.deployment_target = '3.0'
   spec.swift_version = '4.0'
   spec.source       = { :git => "https://github.com/ehn-digital-green-development/base45-swift.git", :tag => "#{spec.version}" }
   spec.source_files  = "Base45-Swift/*.{swift}"


### PR DESCRIPTION
Currently, the iOS deployment target in the podspec file is set to iOS 12. The SPM specification does not point to an iOS version. This PR tries to unify the minimum deployment targets across SPM and cocoapods. This allows users of the SDK to offer the same minimum version for SPM and cocoapods.